### PR TITLE
Improve login and chat UI

### DIFF
--- a/app/src/main/java/com/example/memora/LoginScreen.kt
+++ b/app/src/main/java/com/example/memora/LoginScreen.kt
@@ -3,6 +3,7 @@ package com.example.memoraapp
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.*
+import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -13,9 +14,8 @@ import kotlinx.coroutines.launch
 
 @Composable
 fun LoginScreen(onLoginSuccess: (String) -> Unit) {
-    // Hardcoded username and password for convenience
-    val username = "azad"
-    val password = "azad"
+    var username by remember { mutableStateOf("") }
+    var password by remember { mutableStateOf("") }
     var isLoading by remember { mutableStateOf(false) }
     var error by remember { mutableStateOf<String?>(null) }
 
@@ -43,28 +43,24 @@ fun LoginScreen(onLoginSuccess: (String) -> Unit) {
             modifier = Modifier.fillMaxWidth()
         ) {
             Column(modifier = Modifier.padding(24.dp)) {
-                Text(
-                    text = "Username",
-                    fontSize = 16.sp,
-                    fontWeight = FontWeight.SemiBold,
-                    modifier = Modifier.padding(bottom = 4.dp)
-                )
-                Text(
-                    text = username,
-                    fontSize = 16.sp,
-                    modifier = Modifier.padding(bottom = 16.dp)
+                OutlinedTextField(
+                    value = username,
+                    onValueChange = { username = it },
+                    label = { Text("Username") },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(bottom = 16.dp)
                 )
 
-                Text(
-                    text = "Password",
-                    fontSize = 16.sp,
-                    fontWeight = FontWeight.SemiBold,
-                    modifier = Modifier.padding(bottom = 4.dp)
-                )
-                Text(
-                    text = password,
-                    fontSize = 16.sp,
-                    modifier = Modifier.padding(bottom = 16.dp)
+                OutlinedTextField(
+                    value = password,
+                    onValueChange = { password = it },
+                    label = { Text("Password") },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(bottom = 16.dp),
+                    visualTransformation = PasswordVisualTransformation(),
+                    singleLine = true
                 )
 
                 Button(


### PR DESCRIPTION
## Summary
- let users type username and password
- show chat history for friendlier conversations

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684423be29bc83338b87a2baf7572e7e