### PR TITLE
Add logout button

### DIFF
--- a/app/src/main/java/com/example/memora/ChatScreen.kt
+++ b/app/src/main/java/com/example/memora/ChatScreen.kt
@@ -24,7 +24,7 @@ import kotlinx.coroutines.launch
 import retrofit2.Response
 
 @Composable
-fun ChatScreen(token: String) {
+fun ChatScreen(token: String, onLogout: () -> Unit) {
     var questionInput by remember { mutableStateOf("") }
     val chatHistory = remember { mutableStateListOf<String>() }
     var isLoading by remember { mutableStateOf(false) }
@@ -46,7 +46,12 @@ fun ChatScreen(token: String) {
             TopAppBar(
                 title = { Text("Memora") },
                 backgroundColor = Color(0xFF9C27B0),  // Purple header
-                contentColor = Color.White
+                contentColor = Color.White,
+                actions = {
+                    TextButton(onClick = onLogout) {
+                        Text("Logout", color = Color.White)
+                    }
+                }
             )
         }
     ) { padding ->

--- a/app/src/main/java/com/example/memora/MainActivity.kt
+++ b/app/src/main/java/com/example/memora/MainActivity.kt
@@ -26,7 +26,7 @@ class MainActivity : ComponentActivity() {
                         token = receivedToken
                     }
                 } else {
-                    ChatScreen(token!!)
+                    ChatScreen(token!!, onLogout = { token = null })
                 }
             }
         }


### PR DESCRIPTION
## Summary
- add logout button in the chat screen top bar
- allow MainActivity to reset token when logging out

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68452d22fa5883338d0637bf75a26a44